### PR TITLE
for #99 #102: add tests for globalAwait option

### DIFF
--- a/test/async.spec.ts
+++ b/test/async.spec.ts
@@ -3,7 +3,9 @@
 import * as Eta from '../src/index'
 import { buildRegEx } from './err.spec'
 
-function resolveAfter2Seconds(val: string): Promise<string> {
+type AsyncTimes = {time: number, type: "start" | "end"}[]
+
+function resolveAfter20Milliseconds(val: string): Promise<string> {
   return new Promise((resolve) => {
     setTimeout(() => {
       resolve(val)
@@ -11,8 +13,20 @@ function resolveAfter2Seconds(val: string): Promise<string> {
   })
 }
 
+function createWaitAndStoreTimes(times: AsyncTimes): (val: string) => Promise<string> {
+  return val => new Promise<string>((resolve) => {
+    times.push({time: Date.now(), type: 'start'});
+      setTimeout(() => {
+        resolve(val)
+      }, 200)
+  }).then(x => {
+    times.push({time: Date.now(), type: 'end'});
+    return x;
+  })
+}
+
 async function asyncTest() {
-  const result = await resolveAfter2Seconds('HI FROM ASYNC')
+  const result = await resolveAfter20Milliseconds('HI FROM ASYNC')
   return result
 }
 
@@ -56,6 +70,59 @@ if(cb){cb(null,tR)} return tR
       )
     })
 
+    it('does not await code in eval tags with globalAwait option', async () => {
+      expect(
+        await Eta.render('Hi <% if (it.name) { %>0<% } %>', { name: Promise.resolve(false) }, { async: true, globalAwait: true })
+      ).toEqual('Hi 0')
+    })
+
+    it('automatically awaits promises with the globalAwait option', async () => {
+      expect(
+        await Eta.render('Hi <%= it.name %>', { name: Promise.resolve('Ada Lovelace') }, { async: true, globalAwait: true })
+      ).toEqual('Hi Ada Lovelace')
+    })
+
+    it('globalAwait option works with an empty interpolation tag', async () => {
+      expect(
+        await Eta.render('Hi <%=%>', { }, { async: true, globalAwait: true })
+      ).toEqual('Hi undefined')
+    })
+
+    it('awaits all promises in parallel with the globalAwait option (escaped)', async () => {
+      const times: AsyncTimes =  [];
+      const wait = createWaitAndStoreTimes(times)
+      const result = await Eta.render('Hi <%= it.wait(1) %> <%= it.wait(2) %> <%= it.wait(3) %>', { wait }, { async: true, globalAwait: true })
+      expect(result).toEqual('Hi 1 2 3')
+      times.sort((t1, t2) => t1.time < t2.time ? -1 : t1.time > t2.time ? 1 : 0)
+      expect(times.map(t => t.type).join(',')).toBe('start,start,start,end,end,end')
+    })
+
+    it('awaits all promises in sequence without the globalAwait option (escaped)', async () => {
+      const times: AsyncTimes =  [];
+      const wait = createWaitAndStoreTimes(times)
+      const result = await Eta.render('Hi <%= await it.wait(1) %> <%= await it.wait(2) %> <%= await it.wait(3) %>', { wait }, { async: true, globalAwait: false })
+      expect(result).toEqual('Hi 1 2 3')
+      times.sort((t1, t2) => t1.time < t2.time ? -1 : t1.time > t2.time ? 1 : 0)
+      expect(times.map(t => t.type).join(',')).toBe('start,end,start,end,start,end')
+    })
+
+    it('awaits all promises in parallel with the globalAwait option (raw)', async () => {
+      const times: AsyncTimes =  [];
+      const wait = createWaitAndStoreTimes(times)
+      const result = await Eta.render('Hi <%~ it.wait(1) %> <%~ it.wait(2) %> <%~ it.wait(3) %>', { wait }, { async: true, globalAwait: true })
+      expect(result).toEqual('Hi 1 2 3')
+      times.sort((t1, t2) => t1.time < t2.time ? -1 : t1.time > t2.time ? 1 : 0)
+      expect(times.map(t => t.type).join(',')).toBe('start,start,start,end,end,end')
+    })
+
+    it('awaits all promises in sequence without the globalAwait option (raw)', async () => {
+      const times: AsyncTimes =  [];
+      const wait = createWaitAndStoreTimes(times)
+      const result = await Eta.render('Hi <%~ await it.wait(1) %> <%~ await it.wait(2) %> <%~ await it.wait(3) %>', { wait }, { async: true, globalAwait: false })
+      expect(result).toEqual('Hi 1 2 3')
+      times.sort((t1, t2) => t1.time < t2.time ? -1 : t1.time > t2.time ? 1 : 0)
+      expect(times.map(t => t.type).join(',')).toBe('start,end,start,end,start,end')
+    })
     it('Async template w/ syntax error passes error to callback', (done) => {
       function cb(err: Error | null, _res?: string) {
         expect(err).toBeTruthy()

--- a/test/render.spec.ts
+++ b/test/render.spec.ts
@@ -14,6 +14,9 @@ describe('Simple Render checks', () => {
         'Hi Ada Lovelace!'
       )
     })
+    it('Empty interpolation tag works', () => {
+      expect(render(compile('Hi <%=%>'), {})).toEqual('Hi undefined')
+    })
     it('Rendering function works', () => {
       expect(render(compile('Hi \n<%- =it.name_%>  !'), { name: 'Ada Lovelace' })).toEqual(
         'Hi Ada Lovelace!'


### PR DESCRIPTION
The `globalAwait` option sounds like a very useful feature, which I'd like to use as well. I added some tests for the PR, coverage says it covers all the relevant code of the PR. Hope this can get merged soon!